### PR TITLE
Master activateinternallinks

### DIFF
--- a/src/modules/Content/lib/Content/ContentType/Html.php
+++ b/src/modules/Content/lib/Content/ContentType/Html.php
@@ -66,6 +66,8 @@ class Content_ContentType_Html extends Content_AbstractContentType
             $text = DataUtil::formatForDisplay($this->text);
         } else {
             $text = $this->activateinternallinks(DataUtil::formatForDisplayHTML($this->text));
+            $text = ModUtil::callHooks('item', 'transform', '', array($text));
+            $text = $text[0];
         }
 
         $this->view->assign('inputType', $this->inputType);


### PR DESCRIPTION
the contenttype plugins should call transform hooks and the html-contenttype especially the activateinternallinks-method (which is only called for searchabletext atm in master).
