### PR TITLE
template fixes for flash content type

### DIFF
--- a/src/modules/Content/templates/contenttype/flashmovie_view.tpl
+++ b/src/modules/Content/templates/contenttype/flashmovie_view.tpl
@@ -1,15 +1,45 @@
 {if $displayMode eq 'inline'}
 <dl class="content-video content-shockwave">
     <dt>
-        <object id="csSWF" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="{$width}" height="{$height}" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,115,0">
-            <param name="src" value="{$videoPath}" />
-            <param name="bgcolor" value="#1a1a1a"/>
-            <param name="quality" value="best"/>
-            <param name="allowScriptAccess" value="always"/>
-            <param name="allowFullScreen" value="true"/>
-            <param name="scale" value="showall"/>
-            <embed name="csSWF" src="{$videoPath}" width="{$width}" height="{$height}" bgcolor="#1a1a1a" quality="best" allowScriptAccess="always" allowFullScreen="true" scale="showall"  pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"></embed>
-        </object>
+            {assign var='playerwidth' value=" width=\"`$width`\""}
+            {assign var='playerheight' value=" height=\"`$height`\""}
+
+            {literal}<!--[if !IE]> -->{/literal}
+                <object id="teaser"
+                        type="application/x-shockwave-flash"
+                        data="{$videoPath|safetext}"
+                        {$playerwidth}{$playerheight}>
+                    <param name="pluginurl" value="http://www.macromedia.com/go/getflashplayer" />
+            {literal}<!-- <![endif]-->{/literal}
+
+            {literal}<!--[if IE]>{/literal}
+                <object id="teaser"
+                        classid="clsid:D27CDB6E-AE6D-11CF-96B8-444553540000"
+                        codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,0,0"
+                        {$playerwidth}{$playerheight}>
+                    <param name="movie" value="{$videoPath|safetext}" />
+            {literal}<!--><!---->{/literal}
+
+                    <param name="quality" value="high" />
+                    <param name="menu" value="0" />
+                    <param name="scale" value="showall" />
+                    <param name="salign" value="TL" />
+                    <param name="FlashVars" value="playerMode=embedded" />
+                    <param name="allowScriptAcess" value="sameDomain" />
+
+                    <param name="wmode" value="transparent" />
+                    {* <param name="wmode" value="opaque" /> *}
+
+                    <p>
+                        Your browser does not support embedded flash files.<br />
+                        Please click <a href="{$videoPath|safetext}">here</a> to download the file you requested.<br />
+                        <a href="http://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash" title="Download Flash Player" target="_blank">
+                            {gt text='Download Flash Player'}
+                        </a>
+                    </p>
+                </object>
+            {literal}<!-- <![endif]-->{/literal}
+
     </dt>
     <dd>{$text}</dd>
 {if $author ne ''}
@@ -27,5 +57,5 @@
     </dt>
     <dd><a title="{$videoPath}" caption="{$text}" author="{$author}" href="{$videoPath}" class="play-icon lightwindow page-options" params="lightwindow_width={$width},lightwindow_height={$height},lightwindow_loading_animation=false" title=>{gt text='Play Video'}</a></dd>
 </dl>
-<p><!--[$text]--></p>
+<p>{$text}</p>
 {/if}


### PR DESCRIPTION
These changes make the flash code more passive.

One example for the advantages: if you use css and / or js navigation with submenus appearing on hover now it is possible very easy and quick to get sub navigation items above flash files.

Background: it seemed like different classes of the object tags behave differently. So I changed the code basically to:

```
* support very early versions (flash 6 or similar)
* get rid of embed
```
