### PR TITLE
added option to inherit permissions to child pages

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -17,6 +17,7 @@ Summary of changes:
 - Added 4 column layout
 - Added a setting for showing only some layouts in the new page layout options
 - Updated method categories into categoriesList #154
+- Added option to inherit permissions from parent to child pages
 
 Version 4.1.0
 -------------

--- a/lib/Content/Api/Page.php
+++ b/lib/Content/Api/Page.php
@@ -1438,4 +1438,31 @@ class Content_Api_Page extends Zikula_AbstractApi
 
         return $this->contentUpdateNestedSetValues_Rec($pageId, $level, $count);
     }
+
+    /**
+     * Determines recursively whether the current user has
+     * permissions for a given page or it's parents.
+     *
+     * @param int $pageId
+     * @param int $level
+     */
+    public function checkPermissionForPageInheritance($args)
+    {
+        $pageId = $args['pageId'];
+        $permLevel = $args['level'];
+
+        $component = 'Content:page:';
+
+        if (SecurityUtil::checkPermission($component, $pageId . '::', $permLevel)) {
+            return true;
+        }
+
+        // check for parent
+        $page = $this->getPage(array('id' => $pageId));
+        if (isset($page['parentPageId']) && $page['parentPageId'] !== null && $page['parentPageId'] > 0) {
+            return $this->checkPermissionForPageInheritance(array('pageId' => $page['parentPageId'], 'level' => $permLevel));
+        }
+
+        return false;
+    }
 }

--- a/lib/Content/Controller/User.php
+++ b/lib/Content/Controller/User.php
@@ -50,10 +50,11 @@ class Content_Controller_User extends Zikula_AbstractController
     /**
      * view a page
      *
-     * @param int       pid       Page ID
-     * @param string    name      URL name, alternative for pid
-     * @param bool      preview   Display preview
-     * @param bool      editmode  Activate editmode
+     * @param int    pid      Page ID
+     * @param string name     URL name, alternative for pid
+     * @param bool   preview  Display preview
+     * @param bool   editmode Flag for enabling/disabling edit mode
+     *
      * @return Renderer output
      */
     public function view($args)
@@ -69,7 +70,11 @@ class Content_Controller_User extends Zikula_AbstractController
             System::queryStringSetVar('pid', $pageId);
         }
 
-        $this->throwForbiddenUnless(SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_READ), LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            $this->throwForbiddenUnless(ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $pageId, 'level' => ACCESS_READ)), LogUtil::getErrorMsgPermission());
+        } else {
+            $this->throwForbiddenUnless(SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_READ), LogUtil::getErrorMsgPermission());
+        }
 
         if ($editmode !== null) {
             SessionUtil::setVar('ContentEditMode', $editmode);
@@ -86,7 +91,12 @@ class Content_Controller_User extends Zikula_AbstractController
         }
 
         $versionHtml = '';
-        $hasEditAccess = SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_EDIT);
+        $hasEditAccess = false;
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            $hasEditAccess = ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $pageId, 'level' => ACCESS_EDIT));
+        } else {
+            $hasEditAccess = SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_EDIT);
+        }
 
         if ($versionId !== null && $hasEditAccess) {
             $preview = true;
@@ -255,7 +265,11 @@ class Content_Controller_User extends Zikula_AbstractController
             return LogUtil::registerError($this->__('Error! Unknown page.'), 404);
         }
 
-        $this->throwForbiddenUnless(SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_READ), LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            $this->throwForbiddenUnless(ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $pageId, 'level' => ACCESS_READ)), LogUtil::getErrorMsgPermission());
+        } else {
+            $this->throwForbiddenUnless(SecurityUtil::checkPermission('Content:page:', $pageId . '::', ACCESS_READ), LogUtil::getErrorMsgPermission());
+        }
 
         $topPage = ModUtil::apiFunc('Content', 'Page', 'getPages', array('filter' => array(
             'superParentId' => $pageId),

--- a/lib/Content/Form/Handler/Admin/ClonePage.php
+++ b/lib/Content/Form/Handler/Admin/ClonePage.php
@@ -17,8 +17,14 @@ class Content_Form_Handler_Admin_ClonePage extends Zikula_Form_AbstractHandler
         if (!SecurityUtil::checkPermission('Content:page:', '::', ACCESS_ADD)) {
             throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
         }
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         $page = ModUtil::apiFunc('Content', 'Page', 'getPage', array('id' => $this->pageId, 'filter' => array('checkActive' => false), 'includeContent' => false));
@@ -27,8 +33,14 @@ class Content_Form_Handler_Admin_ClonePage extends Zikula_Form_AbstractHandler
         }
 
         // Only allow subpages if edit access on parent page
-        if (!SecurityUtil::checkPermission('Content:page:', $page['id'] . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $page['id'], 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $page['id'] . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         PageUtil::setVar('title', $this->__('Clone page') . ' : ' . $page['title']);

--- a/lib/Content/Form/Handler/Admin/EditContent.php
+++ b/lib/Content/Form/Handler/Admin/EditContent.php
@@ -55,8 +55,14 @@ class Content_Form_Handler_Admin_EditContent extends Zikula_Form_AbstractHandler
         }
         $this->pageId = $content['pageId'];
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         if (isset($content['plugin'])) {

--- a/lib/Content/Form/Handler/Admin/EditPage.php
+++ b/lib/Content/Form/Handler/Admin/EditPage.php
@@ -14,8 +14,14 @@ class Content_Form_Handler_Admin_EditPage extends Zikula_Form_AbstractHandler
     {
         $this->pageId = (int) FormUtil::getPassedValue('pid', isset($this->args['pid']) ? $this->args['pid'] : -1);
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         $page = ModUtil::apiFunc('Content', 'Page', 'getPage', array(

--- a/lib/Content/Form/Handler/Admin/HistoryContent.php
+++ b/lib/Content/Form/Handler/Admin/HistoryContent.php
@@ -14,9 +14,16 @@ class Content_Form_Handler_Admin_HistoryContent extends Zikula_Form_AbstractHand
         $this->pageId = FormUtil::getPassedValue('pid', isset($this->args['pid']) ? $this->args['pid'] : null);
         $offset = (int)FormUtil::getPassedValue('offset');
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
+
         $page = ModUtil::apiFunc('Content', 'Page', 'getPage', array(
             'id' => $this->pageId, 
             'editing' => false, 

--- a/lib/Content/Form/Handler/Admin/NewContent.php
+++ b/lib/Content/Form/Handler/Admin/NewContent.php
@@ -34,9 +34,16 @@ class Content_Form_Handler_Admin_NewContent extends Zikula_Form_AbstractHandler
             $this->position = ($this->above ? $content['position'] : $content['position'] + 1);
         }
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
+
         if ($this->pageId == null) {
             return $this->view->setErrorMsg($this->__("Missing page ID (pid) in URL"));
         }

--- a/lib/Content/Form/Handler/Admin/NewPage.php
+++ b/lib/Content/Form/Handler/Admin/NewPage.php
@@ -20,8 +20,14 @@ class Content_Form_Handler_Admin_NewPage extends Zikula_Form_AbstractHandler
         }
 
         // Only allow subpages if edit access on parent page
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         if ($this->pageId != null) {

--- a/lib/Content/Form/Handler/Admin/TranslateContent.php
+++ b/lib/Content/Form/Handler/Admin/TranslateContent.php
@@ -30,8 +30,14 @@ class Content_Form_Handler_Admin_TranslateContent extends Zikula_Form_AbstractHa
         }
         $this->pageId = $content['pageId'];
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         $page = ModUtil::apiFunc('Content', 'Page', 'getPage',

--- a/lib/Content/Form/Handler/Admin/TranslatePage.php
+++ b/lib/Content/Form/Handler/Admin/TranslatePage.php
@@ -10,8 +10,14 @@ class Content_Form_Handler_Admin_TranslatePage extends Zikula_Form_AbstractHandl
         $this->pageId = (int) FormUtil::getPassedValue('pid', -1);
         $this->language = ZLanguage::getLanguageCode();
 
-        if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
-            throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+        if ((bool)$this->getVar('inheritPermissions', false) === true) {
+            if (!ModUtil::apiFunc('Content', 'page', 'checkPermissionForPageInheritance', array('pageId' => $this->pageId, 'level' => ACCESS_EDIT))) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
+        } else {
+            if (!SecurityUtil::checkPermission('Content:page:', $this->pageId . '::', ACCESS_EDIT)) {
+                throw new Zikula_Exception_Forbidden(LogUtil::getErrorMsgPermission());
+            }
         }
 
         $page = ModUtil::apiFunc('Content', 'Page', 'getPage', array('id' => $this->pageId, 'includeContent' => false, 'filter' => array('checkActive' => false), 'translate' => false));

--- a/lib/Content/Installer.php
+++ b/lib/Content/Installer.php
@@ -54,6 +54,7 @@ class Content_Installer extends Zikula_AbstractInstaller
         $this->setVar('enableRawPlugin', false);
         $this->setVar('pageinfoLocation', 'top');
         $this->setVar('overrideTitle', true);
+        $this->setVar('inheritPermissions', false);
         // variable that makes it possible to show only specific layouts, depending on templateType
         $this->setVar('layoutDisplay', array(
             array('name' => 'ContentGeneral', 'description' => 'Content styled general layouts', 'display' => true),
@@ -500,6 +501,7 @@ class Content_Installer extends Zikula_AbstractInstaller
     protected function contentUpgrade_4_2_0($oldVersion)
     {
         // add new variable(s)
+        $this->setVar('inheritPermissions', false);
         $this->setVar('layoutDisplay', array(
             array('name' => 'ContentGeneral', 'description' => 'Content styled general layouts', 'display' => true),
             array('name' => 'ContentSpecial', 'description' => 'Content styled special layouts', 'display' => true),

--- a/templates/admin/settings.tpl
+++ b/templates/admin/settings.tpl
@@ -1,10 +1,10 @@
 {adminheader}
 <div class="z-admin-content-pagetitle">
-    {icon type="config" size="small"}
-    <h3>{gt text="Module settings"}</h3>
+    {icon type='config' size='small'}
+    <h3>{gt text='Module settings'}</h3>
 </div>
 
-<p>{gt text="This is where you configure various parts of the content module."}</p>
+<p>{gt text='This is where you configure various parts of the content module.'}</p>
 
 {form cssClass='z-form'}
 
@@ -14,82 +14,86 @@
 {formtabbedpanelset}
 {formtabbedpanel __title='Settings'}
 <fieldset>
-    <legend>{gt text="Settings"}</legend>
+    <legend>{gt text='Settings'}</legend>
     <div class="z-formrow">
         {formlabel for='shorturlsuffix' __text='Short URL suffix'}
-        {formtextinput id='shorturlsuffix' group="config" maxLength='255'}
+        {formtextinput id='shorturlsuffix' group='config' maxLength='255'}
         <em class="z-sub z-formnote">{gt text='File suffix of short URLs (including a dot - for instance ".html"). This is only used if you enable short URLs in Zikula\'s admin section.'}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='newPageState' __text='State of new pages'}
-        {formdropdownlist id='newPageState' items=$activeoptions group="config"}
+        {formdropdownlist id='newPageState' items=$activeoptions group='config'}
     </div>
     <div class="z-formrow">
         {formlabel for='pageinfoLocation' __text='Location of the page info icon'}
-        {formdropdownlist id='pageinfoLocation' items=$pageinfolocationoptions group="config"}
+        {formdropdownlist id='pageinfoLocation' items=$pageinfolocationoptions group='config'}
     </div>
     <div class="z-formrow">
         {formlabel for='overrideTitle' __text='Override page title with the Content page title'}
-        {formcheckbox id='overrideTitle' group="config"}
+        {formcheckbox id='overrideTitle' group='config'}
     </div>
     <div class="z-formrow">
         {formlabel for='countViews' __text='Count page views'}
-        {formcheckbox id='countViews' group="config"}
+        {formcheckbox id='countViews' group='config'}
         <em class="z-sub z-formnote">{gt text='Page views are only counted when not in preview or edit mode and only when the user has no edit access.'}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='enableRawPlugin' __text='Enable the unfiltered raw text plugin'}
-        {formcheckbox id='enableRawPlugin' group="config"}
+        {formcheckbox id='enableRawPlugin' group='config'}
         <em class="z-sub z-formnote">{gt text='Use this plugin with caution and if you can trust your editors, since no filtering is being done on the content. To be used for iframes, JavaScript blocks, etc.'}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='styleClasses' __text='Styling'}
-        {formtextinput id='styleClasses' group="config" textMode='multiline' rows='6' cols='40'}
+        {formtextinput id='styleClasses' group='config' textMode='multiline' rows='6' cols='40'}
         <em class="z-sub z-formnote">{gt text='A list of CSS class names available for styling of content elements. The end user can select one class for each element on a page - for instance "note" for an element styled as a note. Write one class name on each line. Please separate the CSS classes and displaynames with | - eg. "note | Memo".'}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='enableVersioning' __text='Enable version history'}
-        {formcheckbox id='enableVersioning' group="config"}
+        {formcheckbox id='enableVersioning' group='config'}
+    </div>
+    <div class="z-formrow">
+        {formlabel for='inheritPermissions' __text='Inherit permissions from parent to child pages'}
+        {formcheckbox id='inheritPermissions' group='config'}
     </div>
 </fieldset>
 
 <fieldset>
-    <legend>{gt text="Layout choices for new pages"}</legend>
+    <legend>{gt text='Layout choices for new pages'}</legend>
     <div class="z-formrow">
-        {gt text="Choose the layout sets to display during creation of new pages"}
+        {gt text='Choose the layout sets to display during creation of new pages'}
         {formcheckboxlist id='layoutDisplaySelection' items=$layoutdisplayoptions}
     </div>
 </fieldset>
 
 <fieldset>
-    <legend>{gt text="Categories"}</legend>
+    <legend>{gt text='Categories'}</legend>
     <div class="z-formrow">
         {formlabel for='categoryUsage' __text='Category usage'}
-        {formdropdownlist id='categoryUsage' items=$catoptions group="config"}
+        {formdropdownlist id='categoryUsage' items=$catoptions group='config'}
     </div>
     {modurl modname="Categories" type="admin" func="editregistry" assign=urleditregistry}
     <div class="z-formrow">
         {formlabel for='categoryPropPrimary' __text='Category Property for the first category selection'}
-        {formtextinput id='categoryPropPrimary' group="config" maxLength='255'}
+        {formtextinput id='categoryPropPrimary' group='config' maxLength='255'}
         <em class="z-sub z-formnote">{gt text='(In the <a href="%s">category registry</a> you can set the property to use for the first category)' tag1=$urleditregistry|safetext}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='categoryPropSecondary' __text='Category Property for the second category selection'}
-        {formtextinput id='categoryPropSecondary' group="config" maxLength='255'}
+        {formtextinput id='categoryPropSecondary' group='config' maxLength='255'}
         <em class="z-sub z-formnote">{gt text='(In the <a href="%s">category registry</a> you can set the property to use for the second category if being used)' tag1=$urleditregistry|safetext}</em>
     </div>
 </fieldset>
 
 <fieldset>
-    <legend>{gt text="API keys"}</legend>
+    <legend>{gt text='API keys'}</legend>
     <div class="z-formrow">
         {formlabel for='googlemapApiKey' __text='Google maps API key'}
-        {formtextinput id='googlemapApiKey' group="config" maxLength='255'}
+        {formtextinput id='googlemapApiKey' group='config' maxLength='255'}
         <em class="z-sub z-formnote">{gt text='A Google Maps API key is not required for including maps with the Javascript API v3.<br />However an APIs Console key is encouraged by Google. More information at <a href="https://developers.google.com/maps/documentation/javascript/tutorial#api_key">Google</a>.'}</em>
     </div>
     <div class="z-formrow">
         {formlabel for='flickrApiKey' __text='Flickr API key'}
-        {formtextinput id='flickrApiKey' group="config" maxLength='255'}
+        {formtextinput id='flickrApiKey' group='config' maxLength='255'}
         <em class="z-sub z-formnote">{gt text='If your want to add Flickr photos to your content then you need a Flickr API key. You can get this from <a href="http://www.flickr.com/api">flickr.com</a>.'}</em>
     </div>
 </fieldset>
@@ -97,16 +101,16 @@
 {/formtabbedpanel}
 
 {formtabbedpanel __title='Available Plugins'}
-<p class="z-informationmsg">{gt text="Content includes an API that other modules can use to provide their content. Moreover some modules introduce extra functions to plugins delivered with Content."}</p>
+<p class="z-informationmsg">{gt text='Content includes an API that other modules can use to provide their content. Moreover some modules introduce extra functions to plugins delivered with Content.'}</p>
 
 <table id="modules" class="z-admintable">
     <thead>
         <tr>
-            <th>{gt text="Installed"}</th>
-            <th>{gt text="Active"}</th>
-            <th>{gt text="Module"}</th>
-            <th>{gt text="Plugin"}</th>
-            <th>{gt text="Description"}</th>
+            <th>{gt text='Installed'}</th>
+            <th>{gt text='Active'}</th>
+            <th>{gt text='Module'}</th>
+            <th>{gt text='Plugin'}</th>
+            <th>{gt text='Description'}</th>
         </tr>
     </thead>
     <tbody>
@@ -135,8 +139,8 @@
 {/formtabbedpanelset}
 
 <div class="z-formbuttons z-buttons">
-    {formbutton class="z-bt-ok" commandName="save" __text="Save"}
-    {formbutton class="z-bt-cancel" commandName="cancel" __text="Cancel"}
+    {formbutton class="z-bt-ok" commandName="save" __text='Save'}
+    {formbutton class="z-bt-cancel" commandName="cancel" __text='Cancel'}
 </div>
 
 {/contentformframe}


### PR DESCRIPTION
This introduces a new setting which can be used to let child pages inherit their permissions from their parent page.
